### PR TITLE
fix: correct location validation

### DIFF
--- a/terraform-{{cookiecutter.primary_provider}}-{{cookiecutter.module_name}}/variables.tf
+++ b/terraform-{{cookiecutter.primary_provider}}-{{cookiecutter.module_name}}/variables.tf
@@ -24,19 +24,16 @@ The location/region where the Storage Account should be created.
 Changing this forces a new Resource to be created.
 EOT
   validation {
-    condition = alltrue([
-      contains(
-        [
-          "swedencentral",
-          "westeurope",
-          "northeurope",
-          "germanynorth",
-          "germanywestcentral"
-        ],
-        var.location
-      )
-      , var.location)
-    ])
+    condition = contains(
+      [
+        "swedencentral",
+        "westeurope",
+        "northeurope",
+        "germanynorth",
+        "germanywestcentral"
+      ],
+      var.location
+    )
     error_message = <<ERR
 Possible values are `swedencentral`, `westeurope`,
 `northeurope`, `germanynorth`, `germanywestcentral`.


### PR DESCRIPTION
## Summary
- fix location variable validation by replacing incorrect alltrue call with contains

## Testing
- `make fmt` *(fails: terraform: command not found)*
- `make docs` *(fails: terraform-docs: command not found)*
- `make test` *(fails: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a315c4b08323bf342e5c77797858